### PR TITLE
Extend length of string datatypes in Skill

### DIFF
--- a/.jhipster/Skill.json
+++ b/.jhipster/Skill.json
@@ -35,15 +35,27 @@
         },
         {
             "fieldName": "description",
-            "fieldType": "String"
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": "2048"
         },
         {
             "fieldName": "implementation",
-            "fieldType": "String"
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": "2048"
         },
         {
             "fieldName": "validation",
-            "fieldType": "String"
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": "2048"
         },
         {
             "fieldName": "expiryPeriod",

--- a/src/main/java/de/otto/teamdojo/domain/Skill.java
+++ b/src/main/java/de/otto/teamdojo/domain/Skill.java
@@ -30,13 +30,16 @@ public class Skill implements Serializable {
     @Column(name = "title", length = 80, nullable = false)
     private String title;
 
-    @Column(name = "description")
+    @Size(max = 2048)
+    @Column(name = "description", length = 2048)
     private String description;
 
-    @Column(name = "implementation")
+    @Size(max = 2048)
+    @Column(name = "implementation", length = 2048)
     private String implementation;
 
-    @Column(name = "jhi_validation")
+    @Size(max = 2048)
+    @Column(name = "jhi_validation", length = 2048)
     private String validation;
 
     @Pattern(regexp = "^P(?:([-+]?[0-9]+)Y)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)W)?(?:([-+]?[0-9]+)D)?$")

--- a/src/main/java/de/otto/teamdojo/service/dto/SkillDTO.java
+++ b/src/main/java/de/otto/teamdojo/service/dto/SkillDTO.java
@@ -15,10 +15,13 @@ public class SkillDTO implements Serializable {
     @Size(min = 5, max = 80)
     private String title;
 
+    @Size(max = 2048)
     private String description;
 
+    @Size(max = 2048)
     private String implementation;
 
+    @Size(max = 2048)
     private String validation;
 
     @Pattern(regexp = "^P(?:([-+]?[0-9]+)Y)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)W)?(?:([-+]?[0-9]+)D)?$")
@@ -30,7 +33,8 @@ public class SkillDTO implements Serializable {
     @Min(value = 0)
     private Integer score;
 
-    @DecimalMin(value = "0") @DecimalMax(value = "5")
+    @DecimalMin(value = "0")
+    @DecimalMax(value = "5")
     private Double rateScore;
 
     @Min(value = 0)

--- a/src/main/resources/config/liquibase/changelog/20180612164700_extend_skill_descriptions_length.xml
+++ b/src/main/resources/config/liquibase/changelog/20180612164700_extend_skill_descriptions_length.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="20180612164700-1" author="hng">
+        <modifyDataType tableName="skill" columnName="description" newDataType="varchar(2048)"></modifyDataType>
+        <modifyDataType tableName="skill" columnName="implementation" newDataType="varchar(2048)"></modifyDataType>
+        <modifyDataType tableName="skill" columnName="jhi_validation" newDataType="varchar(2048)"></modifyDataType>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -28,4 +28,5 @@
     <include file="config/liquibase/changelog/20180528114846_added_entity_constraints_Comment.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
     <include file="config/liquibase/changelog/20180604134444_initial_demo_data.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20180612164700_extend_skill_descriptions_length.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/src/main/webapp/app/entities/skill/skill-update.component.html
+++ b/src/main/webapp/app/entities/skill/skill-update.component.html
@@ -31,17 +31,35 @@
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.skill.description" for="field_description">Description</label>
                     <input type="text" class="form-control" name="description" id="field_description"
-                        [(ngModel)]="skill.description" />
+                        [(ngModel)]="skill.description" maxlength="2048"/>
+                    <div [hidden]="!(editForm.controls.description?.dirty && editForm.controls.description?.invalid)">
+                        <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.description?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" translateValues="{ max: 2048 }">
+                        This field cannot be longer than 2048 characters.
+                        </small>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.skill.implementation" for="field_implementation">Implementation</label>
                     <input type="text" class="form-control" name="implementation" id="field_implementation"
-                        [(ngModel)]="skill.implementation" />
+                        [(ngModel)]="skill.implementation" maxlength="2048"/>
+                    <div [hidden]="!(editForm.controls.implementation?.dirty && editForm.controls.implementation?.invalid)">
+                        <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.implementation?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" translateValues="{ max: 2048 }">
+                        This field cannot be longer than 2048 characters.
+                        </small>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.skill.validation" for="field_validation">Validation</label>
                     <input type="text" class="form-control" name="validation" id="field_validation"
-                        [(ngModel)]="skill.validation" />
+                        [(ngModel)]="skill.validation" maxlength="2048"/>
+                    <div [hidden]="!(editForm.controls.validation?.dirty && editForm.controls.validation?.invalid)">
+                        <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.validation?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" translateValues="{ max: 2048 }">
+                        This field cannot be longer than 2048 characters.
+                        </small>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="teamdojoApp.skill.expiryPeriod" for="field_expiryPeriod">Expiry Period</label>

--- a/src/main/webapp/i18n/de/skill.json
+++ b/src/main/webapp/i18n/de/skill.json
@@ -32,6 +32,11 @@
             "teams": "Teams",
             "badges": "Badges",
             "levels": "Levels"
+        },
+        "skillDTO": {
+            "description": "description",
+            "validation": "validation",
+            "implementation": "implementation"
         }
     }
 }

--- a/src/main/webapp/i18n/en/skill.json
+++ b/src/main/webapp/i18n/en/skill.json
@@ -32,6 +32,11 @@
             "teams": "Teams",
             "badges": "Badges",
             "levels": "Levels"
+        },
+        "skillDTO": {
+            "description": "description",
+            "validation": "validation",
+            "implementation": "implementation"
         }
     }
 }


### PR DESCRIPTION
The datatype of the columns 'description', 'implementation' and 'jhi_validation' is extended from 255 to 2048