### PR TITLE
Bugfix: Internal server error while deleting teams

### DIFF
--- a/src/main/java/de/otto/teamdojo/domain/Team.java
+++ b/src/main/java/de/otto/teamdojo/domain/Team.java
@@ -52,7 +52,7 @@ public class Team implements Serializable {
                inverseJoinColumns = @JoinColumn(name="participations_id", referencedColumnName="id"))
     private Set<Dimension> participations = new HashSet<>();
 
-    @OneToMany(mappedBy = "team")
+    @OneToMany(mappedBy = "team" , cascade = CascadeType.REMOVE)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<TeamSkill> skills = new HashSet<>();
 


### PR DESCRIPTION
fix: unable to delete teams with existing team skills - added on delete cascade to team -> teamsskill relationship